### PR TITLE
Comply with REUSE version 3.3 for licensing declaration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2020 Arthur A. Gleckler <srfi@speechcode.com>
+#
+# SPDX-License-Identifier: MIT
 *~

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README-for-sample-implementation.md
+++ b/README-for-sample-implementation.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+
+SPDX-License-Identifier: MIT
+-->
+
 # SRFI 197: Pipeline Operators
 
 A Scheme library that implements `chain`, an operator based on [Clojure

--- a/README.org
+++ b/README.org
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2020 Arthur A. Gleckler <srfi@speechcode.com>
+#
+# SPDX-License-Identifier: MIT
+
 * SRFI 197: Pipeline Operators
 
 ** by Adam Nelson

--- a/index.html
+++ b/index.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+
+SPDX-License-Identifier: MIT
+-->
+
 <!DOCTYPE html>
 <html>
   <head>

--- a/srfi-197-syntax-case.scm
+++ b/srfi-197-syntax-case.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ; A syntax-case implementation of SRFI 197.
 ; This should be functionally equivalent to srfi-197.scm,
 ; but it may be easier to read and understand.

--- a/srfi-197.html
+++ b/srfi-197.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+
+SPDX-License-Identifier: MIT
+-->
+
 <!DOCTYPE html><html lang="en"><head>
             <meta charset="utf-8">
             <title>SRFI 197: Pipeline Operators</title>

--- a/srfi-197.scm
+++ b/srfi-197.scm
@@ -1,3 +1,6 @@
+;;; SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+;;;
+;;; SPDX-License-Identifier: MIT
 
 (define-syntax chain
   (syntax-rules …₁ ()

--- a/srfi-197.sld
+++ b/srfi-197.sld
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (define-library (srfi-197)
   (export chain chain-and chain-when chain-lambda nest nest-reverse)
 

--- a/srfi-64-minimal.scm
+++ b/srfi-64-minimal.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 ; Just enough of SRFI 64 (unit tests) to run test.scm.
 
 (define *test-failures* '())

--- a/test-kawa.scm
+++ b/test-kawa.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (define (syntax-violation who msg irr)
   (error msg (cons who irr)))
 

--- a/test-r6rs.scm
+++ b/test-r6rs.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (import (rnrs base)
         (rnrs io ports)
         (rnrs syntax-case))

--- a/test-r7rs.scm
+++ b/test-r7rs.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (import (scheme base)
         (scheme process-context)
         (scheme write)

--- a/test.scm
+++ b/test.scm
@@ -1,3 +1,7 @@
+;;; SPDX-FileCopyrightText: 2020 Adam R. Nelson <adam@nels.onl>
+;;;
+;;; SPDX-License-Identifier: MIT
+
 (include "./srfi-64-minimal.scm")
 
 (define (exclamation x) (string-append x "!"))


### PR DESCRIPTION
This brings this past SRFI to current standards of the SRFI licensing guidelines, as documented in https://srfi.schemers.org/srfi-process.html.