### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2020 Arthur A. Gleckler <srfi@speechcode.com>
-#
+# 
 # SPDX-License-Identifier: MIT
 
 * SRFI 197: Pipeline Operators


### PR DESCRIPTION
Org-mode has this odd whitespace requirement following a leading # to denote a comment.